### PR TITLE
chore(no-extraneous-dependencies): forbid importing from packages not in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ module.exports = {
     'jest/expect-expect': ['error', { assertFunctionNames: ['expect*'] }],
     'jest/no-commented-out-tests': 'error',
     'jest/no-disabled-tests': 'error',
+    'import/no-extraneous-dependencies': [
+      'error',
+      { devDependencies: ['**/*.test.ts', '**/*.spec.ts', '**/e2e/**/*.ts'] },
+    ],
 
     // Disable rules pulled in by "recommended" above that we're failing. It could make
     // sense to work towards enabling these.


### PR DESCRIPTION
docs on this [here](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md)

we recently added this to blockchain-api [here](https://github.com/valora-inc/blockchain-api/pull/347) after a deploy broke due to this [here](https://valora-app.slack.com/archives/C02N3AR2P2S/p1696328446528549)