### PR TITLE
feat: better glob for import/no-extraneous-dependencies with devDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,12 @@ module.exports = {
     'jest/no-disabled-tests': 'error',
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['**/*.test.ts', '**/*.spec.ts', '**/e2e/**/*.ts'] },
+      {
+        devDependencies: [
+          '**/*.{test,spec,e2e}.{ts,tsx}',
+          '**/{e2e,test,scripts}/**/*.{ts,tsx}',
+        ],
+      },
     ],
 
     // Disable rules pulled in by "recommended" above that we're failing. It could make


### PR DESCRIPTION
This should allow to avoid the following unexpected lint errors seen in https://github.com/mobilestack-xyz/hooks/actions/runs/12360477392/job/34495523500?pr=702

```
Run yarn lint
yarn run v1.22.22
$ eslint --ext=.tsx,.ts,.json src/ scripts/

/home/runner/work/hooks/hooks/scripts/getPositions.e2e.ts
Error:   1:1  error  'shelljs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/getPositions.ts
Error:   3:1  error  'yargs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/getShortcuts.e2e.ts
Error:   1:1  error  'shelljs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/getShortcuts.ts
Error:   3:1  error  'yargs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/loadProductionEnvVars.ts
Error:   1:1  error  'js-yaml' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/start.e2e.ts
Error:   1:1  error  'shelljs' should be listed in the project's dependencies, not devDependencies    import/no-extraneous-dependencies
Error:   2:1  error  'terminate' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/start.ts
Error:   2:1  error  'yargs' should be listed in the project's dependencies, not devDependencies            import/no-extraneous-dependencies
Error:   3:1  error  'qrcode-terminal' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
Error:   [4](https://github.com/mobilestack-xyz/hooks/actions/runs/12360477392/job/34495523500?pr=702#step:7:5):1  error  'internal-ip' should be listed in the project's dependencies, not devDependencies      import/no-extraneous-dependencies
Error:   [5](https://github.com/mobilestack-xyz/hooks/actions/runs/12360477392/job/34495523500?pr=702#step:7:6):1  error  'chalk' should be listed in the project's dependencies, not devDependencies            import/no-extraneous-dependencies
Error:   [6](https://github.com/mobilestack-xyz/hooks/actions/runs/12360477392/job/34495523500?pr=702#step:7:7):1  error  'shelljs' should be listed in the project's dependencies, not devDependencies          import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/triggerShortcut.e2e.ts
Error:   1:1  error  'shelljs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/scripts/triggerShortcut.ts
Error:   3:1  error  'yargs' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

/home/runner/work/hooks/hooks/src/types/address.ts
Error:   1:1  error  'abitype' should be listed in the project's dependencies. Run 'npm i -S abitype' to add it  import/no-extraneous-dependencies

✖ [15](https://github.com/mobilestack-xyz/hooks/actions/runs/12360477392/job/34495523500?pr=702#step:7:16) problems (15 errors, 0 warnings)
```

Note: the last one is legit though.